### PR TITLE
Minor text corrections for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Note: ESP32 users please download the `firmware` version - `merged` firmwares ar
 
 ## Compatible Counters
 
-### Annoucing ESPGeiger-HW
+### Announcing ESPGeiger-HW
 
 <img src="https://raw.githubusercontent.com/steadramon/ESPGeiger/main/docs/img/ESPGeiger-HW-STS-5.jpg" width="75%"/>
 <img src="https://raw.githubusercontent.com/steadramon/ESPGeiger/main/docs/img/ESPGeiger-HW-J305.jpg" width="75%"/>

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Use a tool such as esptool.py or Tasmotizer to flash the firmware to your ESP de
 
 ### Building your own image
 
-The project should build automatically with Platformio - it can be built with the Arduino IDE but will require you to satify the requirements by installing the libraries.
+The project should build automatically with Platformio - it can be built with the Arduino IDE but will require you to satisfy the requirements by installing the libraries.
 
 The `environments.ini` file defines some pre-built environments and examples of how the build can be configured. You can pick a combination of target board (esp32/esp8266) and geiger type (pulse/serial/GC10 etc)
 

--- a/lib/default/CircularBuffer-1.3.3/README.md
+++ b/lib/default/CircularBuffer-1.3.3/README.md
@@ -213,7 +213,7 @@ void loop() {
 
 Multiple examples are available in the `examples` folder of the library:
 
- * [CircularBuffer.ino](https://github.com/rlogiacco/CircularBuffer/blob/master/examples/CircularBuffer/CircularBuffer.ino) shows how you can use the library to create a continous averaging of the most recent readings
+ * [CircularBuffer.ino](https://github.com/rlogiacco/CircularBuffer/blob/master/examples/CircularBuffer/CircularBuffer.ino) shows how you can use the library to create a continuous averaging of the most recent readings
  * [EventLogging.ino](https://github.com/rlogiacco/CircularBuffer/blob/master/examples/EventLogging/EventLogging.ino) focuses on dumping the buffer when it becomes full and printing the buffer contents periodically at the same time
  * [Object.ino](https://github.com/rlogiacco/CircularBuffer/blob/master/examples/Object/Object.ino) is meant to demonstrate how to use the buffer to store dynamic structures
  * [Queue.ino](https://github.com/rlogiacco/CircularBuffer/blob/master/examples/Queue/Queue.ino) is a classical example of a queue, or a FIFO data structure

--- a/lib/default/CircularBuffer-1.3.3/README.md
+++ b/lib/default/CircularBuffer-1.3.3/README.md
@@ -275,7 +275,7 @@ Most of the major improvements below have been contributed by [Erlkoenig90](http
 
 ### 1.2.0
 * Added interrupt related macro switch `CIRCULAR_BUFFER_INT_SAFE`
-* Dropped unecessary call to `memset` when clearing
+* Dropped unnecessary call to `memset` when clearing
 
 ### 1.1.1
 * Added tests

--- a/lib/default/ESPNtpClient/readme.md
+++ b/lib/default/ESPNtpClient/readme.md
@@ -46,7 +46,7 @@ This library includes an uptime log too. It counts number of seconds since sketc
 
 Every time that local time is adjusted a `ntpEvent` is thrown. You can attach a function to it using `NTP.onNTPSyncEvent()`. Called function format must be like `void eventHandler(NTPSyncEvent_t event)`.
 
-Library does WiFi connection tracking by itself so you can call begin after or before WiFi is connected and it takes care of WiFi reconnections. Meanwhile, if 'NTP.begin()' is called when WiFi is already connected, it takes far less to get syncronization. It takes up to 30 seconds if library is called before WiFi connection is completed, but it will only take less than 5 seconds if Wifi was connected prior to `NTP.begin()` call
+Library does WiFi connection tracking by itself so you can call begin after or before WiFi is connected and it takes care of WiFi reconnections. Meanwhile, if 'NTP.begin()' is called when WiFi is already connected, it takes far less to get synchronization. It takes up to 30 seconds if library is called before WiFi connection is completed, but it will only take less than 5 seconds if Wifi was connected prior to `NTP.begin()` call
 
 There are two examples, one simple and minimum one to show the very basic implementation. Second one shows advanced use with event and WiFi state management.
 

--- a/lib/default/EasyButton-2.0.3/examples/Interrupts/Interrupts.ino
+++ b/lib/default/EasyButton-2.0.3/examples/Interrupts/Interrupts.ino
@@ -34,7 +34,7 @@ void buttonISR()
 void setup()
 {
 
-  // Initialize Serial for debuging purposes.
+  // Initialize Serial for debugging purposes.
   Serial.begin(BAUDRATE);
 
   Serial.println();

--- a/lib/default/EasyButton-2.0.3/examples/Interrupts/Interrupts.ino
+++ b/lib/default/EasyButton-2.0.3/examples/Interrupts/Interrupts.ino
@@ -2,7 +2,7 @@
   Name:    Interrupts.ino
   Created:  8/11/2019 11:45:52 AM
   Author: José Gabriel Companioni Benítez (https://github.com/elC0mpa)
-  Description: Example to demostrate how to use interrupts in order to improve performance
+  Description: Example to demonstrate how to use interrupts in order to improve performance
 */
 
 #include <Arduino.h>

--- a/lib/default/EasyButton-2.0.3/examples/InterruptsOnPressedFor/InterruptsOnPressedFor.ino
+++ b/lib/default/EasyButton-2.0.3/examples/InterruptsOnPressedFor/InterruptsOnPressedFor.ino
@@ -32,7 +32,7 @@ void buttonISR()
 
 void setup()
 {
-  // Initialize Serial for debuging purposes.
+  // Initialize Serial for debugging purposes.
   Serial.begin(BAUDRATE);
 
   Serial.println();

--- a/lib/default/EasyButton-2.0.3/examples/InterruptsOnPressedFor/InterruptsOnPressedFor.ino
+++ b/lib/default/EasyButton-2.0.3/examples/InterruptsOnPressedFor/InterruptsOnPressedFor.ino
@@ -2,7 +2,7 @@
   Name:    InterruptsOnPressedFor.ino
   Created:  8/17/2019 10:16:52 AM
   Author: José Gabriel Companioni Benítez (https://github.com/elC0mpa)
-  Description: Example to demostrate how to use onPressedFor functionality when using interrupts
+  Description: Example to demonstrate how to use onPressedFor functionality when using interrupts
 */
 
 #include <Arduino.h>

--- a/lib/default/EasyButton-2.0.3/examples/MultipleButtons/MultipleButtons.ino
+++ b/lib/default/EasyButton-2.0.3/examples/MultipleButtons/MultipleButtons.ino
@@ -2,7 +2,7 @@
   Name:		MultipleButtons.ino
   Created:	3/25/2019 11:45:52 AM
   Author:	Evert Arias
-  Description: Example to demostrate how to use the library with more than one button
+  Description: Example to demonstrate how to use the library with more than one button
 */
 
 #include <EasyButton.h>

--- a/lib/default/EasyButton-2.0.3/examples/MultipleButtons/MultipleButtons.ino
+++ b/lib/default/EasyButton-2.0.3/examples/MultipleButtons/MultipleButtons.ino
@@ -32,7 +32,7 @@ void onButton2Pressed()
 
 void setup()
 {
-  // Initialize Serial for debuging purposes
+  // Initialize Serial for debugging purposes
   Serial.begin(BAUDRATE);
 
   Serial.println();

--- a/lib/default/EasyButton-2.0.3/examples/MultipleSequence/MultipleSequence.ino
+++ b/lib/default/EasyButton-2.0.3/examples/MultipleSequence/MultipleSequence.ino
@@ -28,7 +28,7 @@ EasyButton button(BUTTON_PIN);
 
 void setup()
 {
-  // Initialize Serial for debuging purposes.
+  // Initialize Serial for debugging purposes.
   Serial.begin(BAUDRATE);
 
   Serial.println();

--- a/lib/default/EasyButton-2.0.3/examples/MultipleSequence/MultipleSequence.ino
+++ b/lib/default/EasyButton-2.0.3/examples/MultipleSequence/MultipleSequence.ino
@@ -2,7 +2,7 @@
   Name:    MultipleSequence.ino
   Created:  03/23/2020 12:45:23 AM
   Author: José Gabriel Companioni Benítez (https://github.com/elC0mpa)
-  Description: Example to demostrate how to work with multiple sequences 
+  Description: Example to demonstrate how to work with multiple sequences 
 */
 
 #include <Arduino.h>

--- a/lib/default/EasyButton-2.0.3/examples/Pressed/Pressed.ino
+++ b/lib/default/EasyButton-2.0.3/examples/Pressed/Pressed.ino
@@ -23,7 +23,7 @@ void onPressed()
 
 void setup()
 {
-  // Initialize Serial for debuging purposes.
+  // Initialize Serial for debugging purposes.
   Serial.begin(BAUDRATE);
 
   Serial.println();

--- a/lib/default/EasyButton-2.0.3/examples/Pressed/Pressed.ino
+++ b/lib/default/EasyButton-2.0.3/examples/Pressed/Pressed.ino
@@ -2,7 +2,7 @@
  Name:		Pressed.ino
  Created:	9/5/2018 10:49:52 AM
  Author:	Evert Arias
- Description: Example to demostrate how to use the library to detect a single pressed on a button.
+ Description: Example to demonstrate how to use the library to detect a single pressed on a button.
 */
 
 #include <EasyButton.h>

--- a/lib/default/EasyButton-2.0.3/examples/PressedForDuration/PressedForDuration.ino
+++ b/lib/default/EasyButton-2.0.3/examples/PressedForDuration/PressedForDuration.ino
@@ -2,7 +2,7 @@
   Name:		PressedForDuration.ino
   Created:	9/5/2018 10:49:52 AM
   Author:	Evert Arias
-  Description: Example to demostrate how to use the library to detect a pressed for a given duration on a button.
+  Description: Example to demonstrate how to use the library to detect a pressed for a given duration on a button.
 */
 
 #include <EasyButton.h>

--- a/lib/default/EasyButton-2.0.3/examples/PressedForDuration/PressedForDuration.ino
+++ b/lib/default/EasyButton-2.0.3/examples/PressedForDuration/PressedForDuration.ino
@@ -23,7 +23,7 @@ void onPressedForDuration()
 
 void setup()
 {
-  // Initialize Serial for debuging purposes.
+  // Initialize Serial for debugging purposes.
   Serial.begin(BAUDRATE);
 
   Serial.println();

--- a/lib/default/EasyButton-2.0.3/examples/Sequence/Sequence.ino
+++ b/lib/default/EasyButton-2.0.3/examples/Sequence/Sequence.ino
@@ -23,7 +23,7 @@ void onSequenceMatched()
 
 void setup()
 {
-  // Initialize Serial for debuging purposes.
+  // Initialize Serial for debugging purposes.
   Serial.begin(BAUDRATE);
 
   Serial.println();

--- a/lib/default/EasyButton-2.0.3/examples/Sequence/Sequence.ino
+++ b/lib/default/EasyButton-2.0.3/examples/Sequence/Sequence.ino
@@ -2,7 +2,7 @@
   Name:		Sequence.ino
   Created:	9/5/2018 10:49:52 AM
   Author:	Evert Arias
-  Description: Example to demostrate how to use the library to detect a sequence of presses on a button.
+  Description: Example to demonstrate how to use the library to detect a sequence of presses on a button.
 */
 
 #include <EasyButton.h>

--- a/lib/default/EasyButton-2.0.3/examples/TouchButton/TouchButton.ino
+++ b/lib/default/EasyButton-2.0.3/examples/TouchButton/TouchButton.ino
@@ -23,7 +23,7 @@ void onPressed()
 
 void setup()
 {
-  // Initialize Serial for debuging purposes.
+  // Initialize Serial for debugging purposes.
   Serial.begin(BAUDRATE);
 
   Serial.println();

--- a/lib/default/EasyButton-2.0.3/examples/TouchButton/TouchButton.ino
+++ b/lib/default/EasyButton-2.0.3/examples/TouchButton/TouchButton.ino
@@ -2,7 +2,7 @@
   Name:    TouchButton.ino
   Created: 6/25/2019 9:25:52 AM
   Author:  Evert Arias
-  Description: Example to demostrate how to use the library to detect a single touch.
+  Description: Example to demonstrate how to use the library to detect a single touch.
 */
 
 #include <EasyButtonTouch.h>

--- a/lib/default/EasyButton-2.0.3/examples/VirtualButton/VirtualButton.ino
+++ b/lib/default/EasyButton-2.0.3/examples/VirtualButton/VirtualButton.ino
@@ -39,7 +39,7 @@ void buttonPressedForTwoSeconds()
 
 void setup()
 {
-  // Initialize Serial for debuging purposes.
+  // Initialize Serial for debugging purposes.
   Serial.begin(BAUDRATE);
 
   Serial.println();

--- a/lib/default/EasyButton-2.0.3/examples/VirtualButton/VirtualButton.ino
+++ b/lib/default/EasyButton-2.0.3/examples/VirtualButton/VirtualButton.ino
@@ -2,7 +2,7 @@
   Name:    EasyButtonVirtual.ino
   Created:  4/11/2020 1:22:52 AM
   Author: José Gabriel Companioni Benítez (https://github.com/elC0mpa)
-  Description: Example to demostrate how to use the virtual button feature. This allows the user to use a variable as if it were a button. Really useful when 
+  Description: Example to demonstrate how to use the virtual button feature. This allows the user to use a variable as if it were a button. Really useful when 
   the buttons are connected through port expanders like PCF8574.
 */
 

--- a/lib/default/EasyButton-2.0.3/src/EasyButton.cpp
+++ b/lib/default/EasyButton-2.0.3/src/EasyButton.cpp
@@ -39,7 +39,7 @@ bool EasyButton::read()
 	}
 	else
 	{
-		// Debounce time ellapsed.
+		// Debounce time elapsed.
 		_last_state = _current_state;				// Save last state.
 		_current_state = pinVal;					// Assign new state as current state from pin's value.
 		_changed = (_current_state != _last_state); // Report state change if current state vary from last state.

--- a/lib/default/EasyButton-2.0.3/src/EasyButton.cpp
+++ b/lib/default/EasyButton-2.0.3/src/EasyButton.cpp
@@ -34,7 +34,7 @@ bool EasyButton::read()
 
 	if (read_started_ms - _last_change < _db_time)
 	{
-		// Debounce time has not ellapsed.
+		// Debounce time has not elapsed.
 		_changed = false;
 	}
 	else

--- a/lib/default/SdFat-2.2.2/examples/BufferedPrint/BufferedPrint.ino
+++ b/lib/default/SdFat-2.2.2/examples/BufferedPrint/BufferedPrint.ino
@@ -142,7 +142,7 @@ void testMemberFunctions() {
 //#define BASIC_TYPES
 #ifdef BASIC_TYPES
   signed char sc = -1;    // signed 8-bit
-  unsigned char uc = 1;   // unsiged 8-bit
+  unsigned char uc = 1;   // unsigned 8-bit
   signed short ss = -2;   // signed 16-bit
   unsigned short us = 2;  // unsigned 16-bit
   signed long sl = -4;    // signed 32-bit

--- a/lib/default/SdFat-2.2.2/examples/BufferedPrint/BufferedPrint.ino
+++ b/lib/default/SdFat-2.2.2/examples/BufferedPrint/BufferedPrint.ino
@@ -149,7 +149,7 @@ void testMemberFunctions() {
   unsigned long ul = 4;   // unsigned 32-bit
 #else                     // BASIC_TYPES
   int8_t sc = -1;   // signed 8-bit
-  uint8_t uc = 1;   // unsiged 8-bit
+  uint8_t uc = 1;   // unsigned 8-bit
   int16_t ss = -2;  // signed 16-bit
   uint16_t us = 2;  // unsigned 16-bit
   int32_t sl = -4;  // signed 32-bit

--- a/lib/default/SdFat-2.2.2/examples/BufferedPrint/BufferedPrint.ino
+++ b/lib/default/SdFat-2.2.2/examples/BufferedPrint/BufferedPrint.ino
@@ -224,7 +224,7 @@ void setup() {
     sd.initErrorHalt(&Serial);
   }
   Serial.println();
-  Serial.println(F("Test member funcions:"));
+  Serial.println(F("Test member functions:"));
   testMemberFunctions();
   Serial.println();
   Serial.println(

--- a/lib/default/SdFat-2.2.2/examples/SdFormatter/SdFormatter.ino
+++ b/lib/default/SdFat-2.2.2/examples/SdFormatter/SdFormatter.ino
@@ -240,7 +240,7 @@ void setup() {
   c = Serial.read();
   cout << c << endl;
   if (!strchr("EFQ", c)) {
-    cout << F("Quiting, invalid option entered.") << endl;
+    cout << F("Quitting, invalid option entered.") << endl;
     return;
   }
   if (c == 'E' || c == 'F') {

--- a/lib/default/SdFat-2.2.2/examples/SdFormatter/SdFormatter.ino
+++ b/lib/default/SdFat-2.2.2/examples/SdFormatter/SdFormatter.ino
@@ -193,7 +193,7 @@ void setup() {
   c = Serial.read();
   cout << c << endl;
   if (c != 'Y') {
-    cout << F("Quiting, you did not enter 'Y'.\n");
+    cout << F("Quitting, you did not enter 'Y'.\n");
     return;
   }
   // Read any existing Serial data.

--- a/lib/default/SdFat-2.2.2/examples/SdFormatter/SdFormatter.ino
+++ b/lib/default/SdFat-2.2.2/examples/SdFormatter/SdFormatter.ino
@@ -217,7 +217,7 @@ void setup() {
   cout << F("Card size: ") << cardSectorCount / 2097152.0;
   cout << F(" GiB (GiB = 2^30 bytes)\n");
 
-  cout << F("Card will be formated ");
+  cout << F("Card will be formatted ");
   if (cardSectorCount > 67108864) {
     cout << F("exFAT\n");
   } else if (cardSectorCount > 4194304) {

--- a/lib/default/SdFat-2.2.2/examples/SdFormatter/SdFormatter.ino
+++ b/lib/default/SdFat-2.2.2/examples/SdFormatter/SdFormatter.ino
@@ -181,7 +181,7 @@ void setup() {
       "Flash erase sets all data to 0X00 for most cards\n"
       "and 0XFF for a few vendor's cards.\n"
       "\n"
-      "Cards up to 2 GiB (GiB = 2^30 bytes) will be formated FAT16.\n"
+      "Cards up to 2 GiB (GiB = 2^30 bytes) will be formatted FAT16.\n"
       "Cards larger than 2 GiB and up to 32 GiB will be formatted\n"
       "FAT32. Cards larger than 32 GiB will be formatted exFAT.\n"
       "\n"

--- a/lib/default/SdFat-2.2.2/examples/examplesV1/#attic/AnalogLogger/AnalogLogger.ino
+++ b/lib/default/SdFat-2.2.2/examples/examplesV1/#attic/AnalogLogger/AnalogLogger.ino
@@ -22,7 +22,7 @@ ofstream logfile;
 // Serial print stream
 ArduinoOutStream cout(Serial);
 
-// buffer to format data - makes it eaiser to echo to Serial
+// buffer to format data - makes it easier to echo to Serial
 char buf[80];
 //------------------------------------------------------------------------------
 #if SENSOR_COUNT > 6

--- a/lib/default/SdFat-2.2.2/examples/examplesV1/#attic/AnalogLogger/AnalogLogger.ino
+++ b/lib/default/SdFat-2.2.2/examples/examplesV1/#attic/AnalogLogger/AnalogLogger.ino
@@ -11,7 +11,7 @@
 #define SENSOR_COUNT     3  // number of analog pins to log
 #define ECHO_TO_SERIAL   1  // echo data to serial port if nonzero
 #define WAIT_TO_START    1  // Wait for serial input in setup()
-#define ADC_DELAY       10  // ADC delay for high impedence sensors
+#define ADC_DELAY       10  // ADC delay for high impedance sensors
 
 // file system object
 SdFat sd;

--- a/lib/default/SdFat-2.2.2/examples/examplesV1/LongFileName/LongFileName.ino
+++ b/lib/default/SdFat-2.2.2/examples/examplesV1/LongFileName/LongFileName.ino
@@ -77,7 +77,7 @@ void loop() {
   c = Serial.read();
   uint8_t i = c - '0';
   if (!isdigit(c) || i >= n) {
-    Serial.println(F("Invald number"));
+    Serial.println(F("Invalid number"));
     return;
   }
   Serial.println(i);

--- a/lib/default/async-mqtt-client/docs/2.-API-reference.md
+++ b/lib/default/async-mqtt-client/docs/2.-API-reference.md
@@ -14,7 +14,7 @@ Set the keep alive. Defaults to 15 seconds.
 
 #### AsyncMqttClient& setClientId(const char\* `clientId`)
 
-Set the client ID. Defaults to `esp8266<chip ID on 6 hex caracters>`.
+Set the client ID. Defaults to `esp8266<chip ID on 6 hex characters>`.
 
 * **`clientId`**: Client ID
 

--- a/lib/default/async-mqtt-client/docs/2.-API-reference.md
+++ b/lib/default/async-mqtt-client/docs/2.-API-reference.md
@@ -163,4 +163,4 @@ Return the packet ID (or 1 if QoS 0) or 0 if failed.
 
 When disconnected, clears all queued messages
 
-Returns true on succes, false on failure (client is no disconnected)
+Returns true on success, false on failure (client is no disconnected)

--- a/lib/default/async-mqtt-client/docs/3.-Memory-management.md
+++ b/lib/default/async-mqtt-client/docs/3.-Memory-management.md
@@ -5,7 +5,7 @@ AsyncMqttClient buffers outgoing messages in a queue. On sending data is copied 
 ## Outgoing messages
 
 You can send data as long as memory permits. A minimum amount of free memory is set at 4096 bytes. You can lower (or raise) this value by setting `MQTT_MIN_FREE_MEMORY` to your desired value.
-If the free memory was sufficient to send your packet, the `publish` method will return a packet ID indicating the packet was queued. Otherwise, a `0` will be returned, and it's your responsability to resend the packet with `publish`.
+If the free memory was sufficient to send your packet, the `publish` method will return a packet ID indicating the packet was queued. Otherwise, a `0` will be returned, and it's your responsibility to resend the packet with `publish`.
 
 ## Incoming messages
 


### PR DESCRIPTION
Simple typo corrections for better clarity.

### Summary:
- `README.md`, line 63: `satify` → `satisfy`
- `README.md`, line 121: `Annoucing` → `Announcing`
- `lib/default/CircularBuffer-1.3.3/README.md`, line 216: `continous` → `continuous`
- `lib/default/CircularBuffer-1.3.3/README.md`, line 278: `unecessary` → `unnecessary`
- `lib/default/ESPNtpClient/readme.md`, line 49: `syncronization` → `synchronization`
- `lib/default/EasyButton-2.0.3/examples/Interrupts/Interrupts.ino`, line 5: `demostrate` → `demonstrate`
- `lib/default/EasyButton-2.0.3/examples/Interrupts/Interrupts.ino`, line 37: `debuging` → `debugging`
- `lib/default/EasyButton-2.0.3/examples/InterruptsOnPressedFor/InterruptsOnPressedFor.ino`, line 5: `demostrate` → `demonstrate`
- `lib/default/EasyButton-2.0.3/examples/InterruptsOnPressedFor/InterruptsOnPressedFor.ino`, line 35: `debuging` → `debugging`
- `lib/default/EasyButton-2.0.3/examples/MultipleButtons/MultipleButtons.ino`, line 5: `demostrate` → `demonstrate`
- `lib/default/EasyButton-2.0.3/examples/MultipleButtons/MultipleButtons.ino`, line 35: `debuging` → `debugging`
- `lib/default/EasyButton-2.0.3/examples/MultipleSequence/MultipleSequence.ino`, line 5: `demostrate` → `demonstrate`
- `lib/default/EasyButton-2.0.3/examples/MultipleSequence/MultipleSequence.ino`, line 31: `debuging` → `debugging`
- `lib/default/EasyButton-2.0.3/examples/Pressed/Pressed.ino`, line 5: `demostrate` → `demonstrate`
- `lib/default/EasyButton-2.0.3/examples/Pressed/Pressed.ino`, line 26: `debuging` → `debugging`
- `lib/default/EasyButton-2.0.3/examples/PressedForDuration/PressedForDuration.ino`, line 5: `demostrate` → `demonstrate`
- `lib/default/EasyButton-2.0.3/examples/PressedForDuration/PressedForDuration.ino`, line 26: `debuging` → `debugging`
- `lib/default/EasyButton-2.0.3/examples/Sequence/Sequence.ino`, line 5: `demostrate` → `demonstrate`
- `lib/default/EasyButton-2.0.3/examples/Sequence/Sequence.ino`, line 26: `debuging` → `debugging`
- `lib/default/EasyButton-2.0.3/examples/TouchButton/TouchButton.ino`, line 5: `demostrate` → `demonstrate`
- `lib/default/EasyButton-2.0.3/examples/TouchButton/TouchButton.ino`, line 26: `debuging` → `debugging`
- `lib/default/EasyButton-2.0.3/examples/VirtualButton/VirtualButton.ino`, line 5: `demostrate` → `demonstrate`
- `lib/default/EasyButton-2.0.3/examples/VirtualButton/VirtualButton.ino`, line 42: `debuging` → `debugging`
- `lib/default/EasyButton-2.0.3/src/EasyButton.cpp`, line 37: `ellapsed` → `elapsed`
- `lib/default/EasyButton-2.0.3/src/EasyButton.cpp`, line 42: `ellapsed` → `elapsed`
- `lib/default/SdFat-2.2.2/examples/BufferedPrint/BufferedPrint.ino`, line 145: `unsiged` → `unsigned`
- `lib/default/SdFat-2.2.2/examples/BufferedPrint/BufferedPrint.ino`, line 152: `unsiged` → `unsigned`
- `lib/default/SdFat-2.2.2/examples/BufferedPrint/BufferedPrint.ino`, line 227: `funcions` → `functions`
- `lib/default/SdFat-2.2.2/examples/SdFormatter/SdFormatter.ino`, line 184: `formated` → `formatted`
- `lib/default/SdFat-2.2.2/examples/SdFormatter/SdFormatter.ino`, line 196: `Quiting` → `Quitting`
- `lib/default/SdFat-2.2.2/examples/SdFormatter/SdFormatter.ino`, line 220: `formated` → `formatted`
- `lib/default/SdFat-2.2.2/examples/SdFormatter/SdFormatter.ino`, line 243: `Quiting` → `Quitting`
- `lib/default/SdFat-2.2.2/examples/examplesV1/#attic/AnalogLogger/AnalogLogger.ino`, line 14: `impedence` → `impedance`
- `lib/default/SdFat-2.2.2/examples/examplesV1/#attic/AnalogLogger/AnalogLogger.ino`, line 25: `eaiser` → `easier`
- `lib/default/SdFat-2.2.2/examples/examplesV1/LongFileName/LongFileName.ino`, line 80: `Invald` → `Invalid`
- `lib/default/async-mqtt-client/docs/2.-API-reference.md`, line 17: `caracters` → `characters`
- `lib/default/async-mqtt-client/docs/2.-API-reference.md`, line 166: `succes` → `success`
- `lib/default/async-mqtt-client/docs/3.-Memory-management.md`, line 8: `responsability` → `responsibility`

These changes do not alter functionality.